### PR TITLE
Added BINDFAMILY option.

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -38,6 +38,7 @@ opt_param_env_vars:
   - { env_var: "MAXLINES", env_value: "32", desc: "The length of each line is randomized. This controls the maximum length of each line. Shorter lines may keep clients on for longer if they give up after a certain number of bytes." }
   - { env_var: "MAXCLIENTS", env_value: "4096", desc: "Maximum number of connections to accept at a time. Connections beyond this are not immediately rejected, but will wait in the queue." }
   - { env_var: "LOGFILE", env_value: "false", desc: "By default, the app logs to container log. If this is set to `true`, the log will be output to file under `/config/logs/endlessh` (`/config` needs to be mapped)." }
+  - { env_var: "BINDFAMILY", env_value: "-4", desc: "By default, the app binds to IPv4 and IPv6 addresses. Set it to `-4` or `-6` for binding to IPv4 or IPv6 only." }
 opt_param_usage_include_vols: true
 opt_param_volumes:
   - { vol_path: "/config", vol_host_path: "/path/to/appdata", desc: "Required if `LOGFILE` is set to `true`." }
@@ -54,3 +55,4 @@ app_setup_block: |
 # changelog
 changelogs:
   - { date: "16.04.21:", desc: "Initial Release." }
+  - { date: "07.05.21:", desc: "Added BINDFAMILY option." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -38,7 +38,7 @@ opt_param_env_vars:
   - { env_var: "MAXLINES", env_value: "32", desc: "The length of each line is randomized. This controls the maximum length of each line. Shorter lines may keep clients on for longer if they give up after a certain number of bytes." }
   - { env_var: "MAXCLIENTS", env_value: "4096", desc: "Maximum number of connections to accept at a time. Connections beyond this are not immediately rejected, but will wait in the queue." }
   - { env_var: "LOGFILE", env_value: "false", desc: "By default, the app logs to container log. If this is set to `true`, the log will be output to file under `/config/logs/endlessh` (`/config` needs to be mapped)." }
-  - { env_var: "BINDFAMILY", env_value: "-4", desc: "By default, the app binds to IPv4 and IPv6 addresses. Set it to `-4` or `-6` for binding to IPv4 or IPv6 only." }
+  - { env_var: "BINDFAMILY", env_value: "4", desc: "By default, the app binds to IPv4 and IPv6 addresses. Set it to `4` or `6` to bind to IPv4 or IPv6 only." }
 opt_param_usage_include_vols: true
 opt_param_volumes:
   - { vol_path: "/config", vol_host_path: "/path/to/appdata", desc: "Required if `LOGFILE` is set to `true`." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -38,7 +38,7 @@ opt_param_env_vars:
   - { env_var: "MAXLINES", env_value: "32", desc: "The length of each line is randomized. This controls the maximum length of each line. Shorter lines may keep clients on for longer if they give up after a certain number of bytes." }
   - { env_var: "MAXCLIENTS", env_value: "4096", desc: "Maximum number of connections to accept at a time. Connections beyond this are not immediately rejected, but will wait in the queue." }
   - { env_var: "LOGFILE", env_value: "false", desc: "By default, the app logs to container log. If this is set to `true`, the log will be output to file under `/config/logs/endlessh` (`/config` needs to be mapped)." }
-  - { env_var: "BINDFAMILY", env_value: "4", desc: "By default, the app binds to IPv4 and IPv6 addresses. Set it to `4` or `6` to bind to IPv4 or IPv6 only." }
+  - { env_var: "BINDFAMILY", env_value: "", desc: "By default, the app binds to IPv4 and IPv6 addresses. Set it to `4` or `6` to bind to IPv4 only or IPv6 only, respectively. Leave blank to bind to both." }
 opt_param_usage_include_vols: true
 opt_param_volumes:
   - { vol_path: "/config", vol_host_path: "/path/to/appdata", desc: "Required if `LOGFILE` is set to `true`." }
@@ -54,5 +54,5 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "08.06.21:", desc: "Add BINDFAMILY option." }
   - { date: "16.04.21:", desc: "Initial Release." }
-  - { date: "07.05.21:", desc: "Added BINDFAMILY option." }

--- a/root/etc/services.d/endlessh/run
+++ b/root/etc/services.d/endlessh/run
@@ -3,7 +3,8 @@
 export \
     MSDELAY=${MSDELAY:-10000} \
     MAXLINE=${MAXLINE:-32} \
-    MAXCLIENTS=${MAXCLIENTS:-4096}
+    MAXCLIENTS=${MAXCLIENTS:-4096} \
+    BINDFAMILY=${BINDFAMILY:-}
 
 exec 2>&1 \
     s6-setuidgid abc \
@@ -12,4 +13,5 @@ exec 2>&1 \
         -d ${MSDELAY} \
         -l ${MAXLINE} \
         -m ${MAXCLIENTS} \
-        -p 2222
+        -p 2222 \
+        ${BINDFAMILY}

--- a/root/etc/services.d/endlessh/run
+++ b/root/etc/services.d/endlessh/run
@@ -4,7 +4,7 @@ export \
     MSDELAY=${MSDELAY:-10000} \
     MAXLINE=${MAXLINE:-32} \
     MAXCLIENTS=${MAXCLIENTS:-4096} \
-    BINDFAMILY=${BINDFAMILY:-}
+    BINDFAMILY=$(test v4 = v${BINDFAMILY} -o v6 = v${BINDFAMILY} && echo -${BINDFAMILY})
 
 exec 2>&1 \
     s6-setuidgid abc \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-endlessh/blob/main/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
By default, endlessh tries to bind to both ipv4 and ipv6 family addresses. When ipv6 is disabled, it floods log with warnings:
```
2021-05-07 14:58:56.269253829  2021-05-07T12:58:56.269Z BindFamily IPv4 Mapped IPv6
2021-05-07 14:58:56.272183238  endlessh: fatal: Address family not supported by protocol
```

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
By adding this new option, one can choose the desired bind IP family.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I run it locally on my Linux machine with ipv6 disabled and verified that adding BINDFAMILY=-4 indeed removes those warnings. In the log I can see:
```
2021-05-07 15:03:46.918177017  2021-05-07T13:03:46.905Z BindFamily IPv4 Only
```